### PR TITLE
Switched parameters in loss function

### DIFF
--- a/site/en/guide/basic_training_loops.ipynb
+++ b/site/en/guide/basic_training_loops.ipynb
@@ -275,7 +275,7 @@
         "plt.scatter(x, model(x), c=\"r\")\n",
         "plt.show()\n",
         "\n",
-        "print(\"Current loss: %1.6f\" % loss(model(x), y).numpy())"
+        "print(\"Current loss: %1.6f\" % loss(y, model(x)).numpy())"
       ]
     },
     {


### PR DESCRIPTION
In the loss visualization step, the parameters for the loss function were in the wrong order (while this doesn't affect the outcome, it may be confusing).